### PR TITLE
[TASK] Adds inline tree selector example

### DIFF
--- a/Configuration/TCA/tx_styleguide_forms_inline_2_child1.php
+++ b/Configuration/TCA/tx_styleguide_forms_inline_2_child1.php
@@ -164,17 +164,56 @@ return array(
 				),
 			),
 		),
+		'inline_3' => array(
+			'exclude' => 1,
+			'label' => '3 renderMode=tree of pages',
+			'config' => array(
+				'type' => 'select',
+				'foreign_table' => 'pages',
+				'size' => 20,
+				'maxitems' => 4, // @TODO: *must* be set, otherwise invalid upon checking first item?!
+				'renderMode' => 'tree',
+				'treeConfig' => array(
+					'expandAll' => true,
+					'parentField' => 'pid',
+					'appearance' => array(
+						'showHeader' => TRUE,
+					),
+				),
+			),
+		),
+		'inline_4' => array(
+			'exclude' => 1,
+			'label' => '4 renderMode=tree of pages showHeader=FALSE, nonSelectableLevels=0,1, allowRecursiveMode=TRUE, width=400',
+			'config' => array(
+				'type' => 'select',
+				'foreign_table' => 'pages',
+				'maxitems' => 4, // @TODO: *must* be set, otherwise invalid upon checking first item?!
+				'size' => 10,
+				'renderMode' => 'tree',
+				'treeConfig' => array(
+					'expandAll' => true,
+					'parentField' => 'pid',
+					'appearance' => array(
+						'showHeader' => FALSE,
+						'nonSelectableLevels' => '0,1',
+						'allowRecursiveMode' => TRUE, // @TODO: No effect?
+						'width' => 400,
+					),
+				),
+			),
+		),
 	),
 	'interface' => array(
 		'showRecordFieldList' => '
 			sys_language_uid, l18n_parent, l18n_diffsource, hidden, parentid, parenttable,
-			input_1, inline_1, inline_2,
+			input_1, inline_1, inline_2, inline_3, inline_4
 		',
 	),
 	'types' => array(
 		'0' => array(
 			'showitem' => '
-				--div--;General, input_1, inline_1, inline_2,
+				--div--;General, input_1, inline_1, inline_2, inline_3, inline_4
 				--div--;Visibility, sys_language_uid, l18n_parent, l18n_diffsource, hidden, parentid, parenttable
 			',
 		),

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -355,6 +355,8 @@ CREATE TABLE tx_styleguide_forms_inline_2_child1 (
 	input_1 text NOT NULL,
 	inline_1 int(11) DEFAULT '0' NOT NULL,
 	inline_2 int(11) DEFAULT '0' NOT NULL,
+	inline_3 text NOT NULL,
+	inline_4 text NOT NULL,
 
 	PRIMARY KEY (uid),
 	KEY parent (pid)


### PR DESCRIPTION
Testcase for a select with renderMdoe=tree inside an IRRE element.

At the moment only the first select (inline_3) will be displayed and the second one (inline_4) will vanish. If you change the order of the fields, the same happens: inline_4 will be "dsplayed" and inline_3 not. 

As requested in Ticket https://forge.typo3.org/issues/68013