### PR TITLE
[TASK] Remove loadPrototype argument

### DIFF
--- a/Resources/Private/Layouts/Default.html
+++ b/Resources/Private/Layouts/Default.html
@@ -5,7 +5,6 @@
 		1: '{f:uri.resource(path:\'Css/styles.css\')}'
 	}"
 	includeRequireJsModules="{0: 'TYPO3/CMS/Styleguide/FindIcons'}"
-	loadPrototype="0"
 	loadExtJsTheme="0"
 	loadJQuery="1"
 >


### PR DESCRIPTION
since prototype is not part of the TYPO3 core, the argument was removed.