### PR TITLE
Add missing inline_4 sql definition for styleguide_form

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -180,6 +180,7 @@ CREATE TABLE tx_styleguide_forms (
 	inline_1 int(11) DEFAULT '0' NOT NULL,
 	inline_2 int(11) DEFAULT '0' NOT NULL,
 	inline_3 int(11) DEFAULT '0' NOT NULL,
+	inline_4 int(11) DEFAULT '0' NOT NULL,
 
 	palette_1_1 int(11) DEFAULT '0' NOT NULL,
 	palette_1_2 text,


### PR DESCRIPTION
TCA contains a definition of inline4 field, but it's missing in the sql. which caused sql error on saving