### PR TITLE
[BUGFIX] Add dummy_1 field to tx_styleguide_inlineexpand_inline_1_child1

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -568,6 +568,7 @@ CREATE TABLE tx_styleguide_inlineexpand_inline_1_child1 (
 
 	rte_1 text NOT NULL,
 	tree_1 text NOT NULL,
+	dummy_1 text NOT NULL,
 	fal_1 int(11) DEFAULT '0' NOT NULL,
 
 	PRIMARY KEY (uid),


### PR DESCRIPTION
Add missing field to ext_tables.sql to enable saving test records of inline collapse/expand tests.