### PR TITLE
[BUGFIX] Flexform inline_2 FAL record config

### DIFF
--- a/Configuration/Flexform/Flex_3.xml
+++ b/Configuration/Flexform/Flex_3.xml
@@ -437,8 +437,8 @@
 								<foreign_match_fields>
 									<fieldname>fal</fieldname>
 								</foreign_match_fields>
-								<forgein_label>uid_local</forgein_label>
-								<foreig_serlector>uid_local</foreig_serlector>
+								<foreign_label>uid_local</foreign_label>
+								<foreign_selector>uid_local</foreign_selector>
 								<foreign_selector_fieldTcaOverride>
 									<config>
 										<appearance>


### PR DESCRIPTION
Fix the spelling of XML elements for foreign_label and foreign_selector