### PR TITLE
[TASK] Set minimum TYPO3 version to 7.6.1 due to the use of the TCA type group with internal_type folder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,6 @@
     }
   },
   "require": {
-    "typo3/cms-core": ">=7.6.0,<8.0"
+    "typo3/cms-core": ">=7.6.1,<8.0"
   }
 }

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = array(
     'version' => '7.6.0',
     'constraints' => array(
         'depends' => array(
-            'typo3' => '7.6.0-7.99.99',
+            'typo3' => '7.6.1-7.99.99',
         ),
         'conflicts' => array(
         ),


### PR DESCRIPTION
The following error occurs in TYPO3 7.6.0 when you hit the form engine test button:

> TCA internal_type of field "group_13" in table tx_styleguide_forms must be set to either "db", "file" or "file_reference"

This is the result of the following [Bug #70449](https://forge.typo3.org/issues/70449) which has been fixed with the release of TYPO3 7.6.1.
