### PR TITLE
[BUGFIX] Remove invalid default values from input_36/input_37

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -72,8 +72,8 @@ CREATE TABLE tx_styleguide_elements_basic (
 	input_32 text,
 	input_33 text,
 	input_34 text,
-	input_36 date NOT NULL DEFAULT '0000-00-00',
-	input_37 datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+	input_36 date,
+	input_37 datetime,
 
 	text_1 text,
 	text_2 text,


### PR DESCRIPTION
MySQL 5.7.8+ have included NO_ZERO_DATE/NO_ZERO_IN_DATE in the strict
mode settings and have strict mode enabled as default. The default
values of 0000-00-00 and 0000-00-00 00:00:00 are incompatible with
that setting and trigger SQL errors when inserting data or creating
the table.