### PR TITLE
Tune selectTree examples

### DIFF
--- a/Configuration/TCA/tx_styleguide_elements_select.php
+++ b/Configuration/TCA/tx_styleguide_elements_select.php
@@ -465,7 +465,6 @@ return [
                 'renderType' => 'selectTree',
                 'foreign_table' => 'pages',
                 'size' => 20,
-                // @todo: *must* be set, otherwise invalid upon checking first item?!
                 'maxitems' => 4,
                 'treeConfig' => [
                     'parentField' => 'pid',
@@ -483,7 +482,6 @@ return [
                 'type' => 'select',
                 'renderType' => 'selectTree',
                 'foreign_table' => 'pages',
-                // @todo: *must* be set, otherwise invalid upon checking first item?!
                 'maxitems' => 4,
                 'size' => 10,
                 'treeConfig' => [
@@ -498,14 +496,14 @@ return [
         ],
         'select_tree_3' => [
             'exclude' => 1,
-            'label' => 'select_tree_3 pages, maxLevels=1',
+            'label' => 'select_tree_3 pages, maxLevels=1, minitems=1, maxitems=2',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectTree',
                 'foreign_table' => 'pages',
                 'size' => 20,
-                // @todo: *must* be set, otherwise invalid upon checking first item?!
-                'maxitems' => 4,
+                'minitems' => 1,
+                'maxitems' => 2,
                 'treeConfig' => [
                     'parentField' => 'pid',
                     'appearance' => [
@@ -524,7 +522,6 @@ return [
                 'renderType' => 'selectTree',
                 'foreign_table' => 'pages',
                 'size' => 20,
-                // @todo: *must* be set, otherwise invalid upon checking first item?!
                 'maxitems' => 4,
                 'treeConfig' => [
                     'parentField' => 'pid',

--- a/Configuration/TCA/tx_styleguide_elements_select.php
+++ b/Configuration/TCA/tx_styleguide_elements_select.php
@@ -20,7 +20,7 @@ return [
             'starttime' => 'starttime',
             'endtime' => 'endtime',
         ],
-        'requestUpdate' => 'select_requestUpdate_1',
+        'requestUpdate' => 'select_requestUpdate_1,select_tree_4',
     ],
 
 
@@ -459,7 +459,7 @@ return [
 
         'select_tree_1' => [
             'exclude' => 1,
-            'label' => 'select_tree_1 pages',
+            'label' => 'select_tree_1 pages, showHeader=true, expandAll=true, size=20, maxitems=4',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectTree',
@@ -468,9 +468,9 @@ return [
                 // @todo: *must* be set, otherwise invalid upon checking first item?!
                 'maxitems' => 4,
                 'treeConfig' => [
-                    'expandAll' => true,
                     'parentField' => 'pid',
                     'appearance' => [
+                        'expandAll' => true,
                         'showHeader' => true,
                     ],
                 ],
@@ -478,7 +478,7 @@ return [
         ],
         'select_tree_2' => [
             'exclude' => 1,
-            'label' => 'select_tree_2 pages, showHeader=false, nonSelectableLevels=0,1, allowRecursiveMode=true, width=400',
+            'label' => 'select_tree_2 pages, showHeader=false, nonSelectableLevels=0,1, maxitems=4, size=10',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectTree',
@@ -487,9 +487,9 @@ return [
                 'maxitems' => 4,
                 'size' => 10,
                 'treeConfig' => [
-                    'expandAll' => true,
                     'parentField' => 'pid',
                     'appearance' => [
+                        'expandAll' => true,
                         'showHeader' => false,
                         'nonSelectableLevels' => '0,1'
                     ],
@@ -507,10 +507,10 @@ return [
                 // @todo: *must* be set, otherwise invalid upon checking first item?!
                 'maxitems' => 4,
                 'treeConfig' => [
-                    'expandAll' => true,
                     'parentField' => 'pid',
                     'appearance' => [
                         'showHeader' => true,
+                        'expandAll' => true,
                         'maxLevels' => 1,
                     ],
                 ],
@@ -518,7 +518,7 @@ return [
         ],
         'select_tree_4' => [
             'exclude' => 1,
-            'label' => 'select_tree_4 pages, maxLevels=2',
+            'label' => 'select_tree_4 pages, maxLevels=2, requestUpdate, expandAll=false',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectTree',
@@ -527,11 +527,30 @@ return [
                 // @todo: *must* be set, otherwise invalid upon checking first item?!
                 'maxitems' => 4,
                 'treeConfig' => [
-                    'expandAll' => true,
+                    'parentField' => 'pid',
+                    'appearance' => [
+                        'expandAll' => false,
+                        'showHeader' => true,
+                        'maxLevels' => 2,
+                    ],
+                ],
+            ],
+        ],
+        'select_tree_5' => [
+            'exclude' => 1,
+            'label' => 'select_tree_5 pages, readOnly, showHeader=true',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectTree',
+                'foreign_table' => 'pages',
+                'size' => 20,
+                'readOnly' => true,
+                'maxitems' => 4,
+                'treeConfig' => [
                     'parentField' => 'pid',
                     'appearance' => [
                         'showHeader' => true,
-                        'maxLevels' => 2,
+                        'expandAll' => true,
                     ],
                 ],
             ],
@@ -760,7 +779,7 @@ return [
                     select_multiplesidebyside_1, select_multiplesidebyside_2, select_multiplesidebyside_3,
                     select_multiplesidebyside_4, select_multiplesidebyside_5, select_multiplesidebyside_6,
                 --div--;renderType=selectTree,
-                    select_tree_1, select_tree_2, select_tree_3, select_tree_4,
+                    select_tree_1, select_tree_2, select_tree_3, select_tree_4, select_tree_5,
                 --div--;in flex,
                     flex_1,
                 --div--;requestUpdate,

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -489,6 +489,7 @@ CREATE TABLE tx_styleguide_elements_select (
 	select_tree_2 text,
 	select_tree_3 text,
 	select_tree_4 text,
+	select_tree_5 text,
 
 	flex_1 text,
 


### PR DESCRIPTION
- Remove not used allowRecursiveMode and width settings.
- Improve labels.
- Fix misplaced expandAll setting
- Add tree with requestUpdate setting
- Add tree with readOnly=true