### PR TITLE
[TASK] Add an example for a selectCheckBox field with multiple defaults

### DIFF
--- a/Configuration/TCA/tx_styleguide_valuesdefault.php
+++ b/Configuration/TCA/tx_styleguide_valuesdefault.php
@@ -178,6 +178,22 @@ return [
                 'default' => 2,
             ],
         ],
+        'select_2' => [
+            'exclude' => 1,
+            'label' => 'select_2 default=1,3 renderType=selectCheckBox, maxitems=999',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectCheckBox',
+                'maxitems' => 999,
+                'items' => [
+                    ['foo 1', 1],
+                    ['foo 2', 2],
+                    ['foo 3', 3],
+                    ['foo 4', 4],
+                ],
+                'default' => '1,3'
+            ],
+        ],
 
     ],
 
@@ -191,7 +207,7 @@ return [
                     checkbox_1, checkbox_2, checkbox_3,
                     radio_1,
                 --div--;select,
-                    select_1,
+                    select_1,select2,
             ',
         ],
     ],

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -2082,6 +2082,7 @@ CREATE TABLE tx_styleguide_valuesdefault (
 	radio_1 int(11) DEFAULT '0' NOT NULL,
 
 	select_1 text,
+	select_2 text,
 
 	PRIMARY KEY (uid),
 	KEY parent (pid)


### PR DESCRIPTION
There is currently a bug in the core preventing the field from being saved
with no value selected.